### PR TITLE
Codemods sometimes fail to complete if execution path is changed

### DIFF
--- a/src/components/engineService.ts
+++ b/src/components/engineService.ts
@@ -3,7 +3,7 @@ import prettyReporter from 'io-ts-reporters';
 import { ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
 import * as readline from 'node:readline';
 import { FileSystem, Uri, window } from 'vscode';
-import { Case, CaseKind, CaseWithJobHashes } from '../cases/types';
+import { CaseKind, CaseWithJobHashes } from '../cases/types';
 import { Configuration } from '../configuration';
 import { Container } from '../container';
 import { buildJobHash } from '../jobs/buildJobHash';
@@ -105,7 +105,7 @@ type Execution = {
 	halted: boolean;
 	affectedAnyFile: boolean;
 	readonly jobs: Job[];
-	case?: Case;
+	case: CaseWithJobHashes;
 };
 
 const codemodEntryCodec = buildTypeCodec({
@@ -388,6 +388,7 @@ export class EngineService {
 			totalFileCount: 0, // that is the lower bound,
 			affectedAnyFile: false,
 			jobs: [],
+			case: {} as CaseWithJobHashes,
 		};
 		if (
 			'kind' in message.command &&
@@ -581,7 +582,7 @@ export class EngineService {
 		});
 
 		interfase.on('close', async () => {
-			if (this.#execution && this.#execution.case) {
+			if (this.#execution) {
 				this.#messageBus.publish({
 					kind: MessageKind.codemodSetExecuted,
 					executionId: this.#execution.executionId,

--- a/src/components/messageBus.ts
+++ b/src/components/messageBus.ts
@@ -1,5 +1,5 @@
 import { Disposable, EventEmitter, Uri } from 'vscode';
-import type { Case, CaseHash, CaseWithJobHashes } from '../cases/types';
+import type { CaseHash, CaseWithJobHashes } from '../cases/types';
 import type { Job, JobHash } from '../jobs/types';
 import type { Configuration } from '../configuration';
 import { CodemodHash } from '../packageJsonAnalyzer/types';
@@ -171,7 +171,7 @@ export type Message =
 			halted: boolean;
 			fileCount: number;
 			jobs: Job[];
-			case: Case;
+			case: CaseWithJobHashes;
 	  }>
 	| Readonly<{
 			kind: MessageKind.extensionActivated;

--- a/src/components/webview/CampaignManagerProvider.ts
+++ b/src/components/webview/CampaignManagerProvider.ts
@@ -315,6 +315,9 @@ export class CampaignManagerProvider implements WebviewViewProvider {
 		);
 
 		this.__addHook(MessageKind.codemodSetExecuted, (message) => {
+			if (!message.case.hash) {
+				return;
+			}
 			commands.executeCommand('intuita.openCaseDiff', message.case.hash);
 		});
 	}


### PR DESCRIPTION
bug coming from https://github.com/intuita-inc/intuita-vscode-extension/commit/22c53f17aa4c1bb7eee3d21bdf29efb5c51de816

### Linear: https://linear.app/intuita/issue/INT-1088/codemods-sometimes-fail-to-complete-if-execution-path-is-changed