### PR TITLE
[Change Explorer] Expand collapsed folder on arrow-right and move to diff view for expanded folder

### DIFF
--- a/intuita-webview/src/shared/Tree/index.tsx
+++ b/intuita-webview/src/shared/Tree/index.tsx
@@ -42,7 +42,7 @@ const Tree = ({
 			return;
 		}
 
-		if (key === 'ArrowRight') {
+		if (key === 'ArrowRight' && (hasNoChildren || open)) {
 			vscode.postMessage({
 				kind: 'webview.global.focusView',
 				webviewName: 'diffView',
@@ -50,7 +50,9 @@ const Tree = ({
 			return;
 		}
 
-		setIsOpen(key === 'ArrowLeft' ? false : true);
+		if (!hasNoChildren) {
+			setIsOpen(key === 'ArrowLeft' ? false : true);
+		}
 	};
 
 	useKey('ArrowLeft', () => {


### PR DESCRIPTION
(2) of https://linear.app/intuita/issue/INT-1072/improvement-of-keyboard-arrows-in-change-explorer

Arrow-right on collapsed folder item must expand it, but it was moving focus to the diff view. Now, it expands the folder. If user presses arrow-right on expanded folder, focus will move to the diff view.

### Claap: https://app.claap.io/intuita/change-explorer-expand-collapsed-folder-on-arrow-right-and-move-to-diff-view-for-expanded-folder-c-BT2DRbCjzO-eoLYD96T5Kk6