### PR TITLE
Refactor FileExplorer

### DIFF
--- a/intuita-webview/src/fileExplorer/App.tsx
+++ b/intuita-webview/src/fileExplorer/App.tsx
@@ -15,7 +15,9 @@ import { vscode } from '../shared/utilities/vscode';
 type ViewProps = Extract<View, { viewId: 'fileExplorer' }>['viewProps'];
 
 function App() {
-	const [viewProps, setViewProps] = useState<ViewProps>(null);
+	const [viewProps, setViewProps] = useState<ViewProps>(
+		window.INITIAL_STATE.viewProps as ViewProps,
+	);
 	const [searchQuery, setSearchQuery] = useState<string>('');
 	const [stagedJobs, setStagedJobs] = useState<JobHash[]>([]);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -443,10 +443,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					kind: MessageKind.updateElements,
 				});
 
-				fileExplorerProvider.setView({
-					viewId: 'fileExplorer',
-					viewProps: null,
-				});
+				fileExplorerProvider.clearView();
 			} catch (e) {
 				const message = e instanceof Error ? e.message : String(e);
 				vscode.window.showErrorMessage(message);
@@ -469,7 +466,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
 				fileExplorerProvider.setCaseHash(caseHash);
 				fileExplorerProvider.showView();
-				fileExplorerProvider.updateExplorerView(caseHash);
+				fileExplorerProvider.setView(caseHash);
 
 				errorWebviewProvider.showView();
 				errorWebviewProvider.setView();


### PR DESCRIPTION
- refactors `FileExplorerProvider`, removing unnecessary code
- initialises `viewProps` of File explorer panel to `window.INITIAL_STATE.viewProps`