### PR TITLE
Dynamic UI depending on screen size to show dry-run better

### DIFF
--- a/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
+++ b/intuita-webview/src/codemodList/TreeView/TreeItem.tsx
@@ -213,7 +213,7 @@ const TreeItem = ({
 				</>
 			)}
 			<div className="flex w-full flex-col">
-				<span className={styles.label}>
+				<span className={styles.labelContainer}>
 					<Popover
 						trigger={
 							<span
@@ -223,6 +223,10 @@ const TreeItem = ({
 									}),
 									userSelect: 'none',
 								}}
+								className={cn(
+									kind === 'codemodItem' &&
+										styles.codemodItemLabel,
+								)}
 							>
 								{label}
 							</span>
@@ -255,11 +259,15 @@ const TreeItem = ({
 						)}
 					</span>
 				</span>
-
 				{progressBar}
 			</div>
 			{!editingPath && (
-				<div className={styles.actions}>
+				<div
+					className={cn(
+						styles.actions,
+						kind === 'codemodItem' && styles.codemodItemActions,
+					)}
+				>
 					{actionButtons.map((el) => el)}
 				</div>
 			)}

--- a/intuita-webview/src/codemodList/TreeView/style.module.css
+++ b/intuita-webview/src/codemodList/TreeView/style.module.css
@@ -30,6 +30,13 @@
 	display: flex;
 }
 
+.root .codemodItemActions,
+.root .directorySelector {
+	@media (max-width: 250px) {
+		display: flex;
+	}
+}
+
 .root:hover .description {
 	display: inline;
 }
@@ -54,7 +61,7 @@
 	height: 16px;
 }
 
-.label {
+.labelContainer {
 	line-height: 22px;
 	font-size: 13px;
 	cursor: pointer;
@@ -66,6 +73,12 @@
 	width: 100%;
 	display: flex;
 	align-items: center;
+}
+
+.codemodItemLabel {
+	@media (max-width: 250px) {
+		display: none;
+	}
 }
 
 .description {


### PR DESCRIPTION
#### Changes
- on screen-width smaller than 250px, display execution path and dry-run button (not just on hover) and hide codemod label

#### Claap: https://app.claap.io/intuita/dynamic-ui-depending-on-screen-size-to-show-dry-run-better-c-BT2DRbCjzO-0Z857OLYkFH6
#### Linear: https://linear.app/intuita/issue/INT-1110/dry-run-position-needs-to-be-fixed-when-left-bar-is-narrow