### PR TITLE
INT-1235 Fix margin of tree items in discovery panel

### DIFF
--- a/intuita-webview/src/codemodList/CodemodNodeRenderer/index.tsx
+++ b/intuita-webview/src/codemodList/CodemodNodeRenderer/index.tsx
@@ -50,13 +50,14 @@ const getIcon = (
 
 const getContainerInlineStyles = ({
 	depth,
+	node,
 }: NodeDatum<CodemodNodeHashDigest, CodemodNode>) => {
 	return {
-		...(depth === 1 && {
-			minWidth: '0.25rem',
-		}),
-		...(depth > 1 && {
+		...(depth > 0 && {
 			minWidth: `${5 + depth * 16}px`,
+		}),
+		...(node.kind === 'CODEMOD' && {
+			minWidth: `${8 + (depth + 1) * 16}px`,
 		}),
 	};
 };


### PR DESCRIPTION
#### Before
<img width="442" alt="Screenshot 2023-06-23 at 10 29 07" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/889503d2-9b1c-423d-9ff9-6e9c1e282529">

#### After
<img width="432" alt="Screenshot 2023-06-23 at 10 28 29" src="https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/14c205ae-ff00-4a1b-972e-b39a1db153be">
