### PR TITLE
Fix Action Footer style when screen width is < 330 px

### DIFF
--- a/intuita-webview/src/fileExplorer/ActionsFooter/index.tsx
+++ b/intuita-webview/src/fileExplorer/ActionsFooter/index.tsx
@@ -49,7 +49,7 @@ export const ActionsFooter = ({
 			className={styles.root}
 			style={{
 				...(screenWidth !== null &&
-					screenWidth < 330 && { marginRight: 'auto' }),
+					screenWidth >= 330 && { justifyContent: 'flex-end' }),
 			}}
 		>
 			<IntuitaPopover content={POPOVER_TEXTS.discard}>

--- a/intuita-webview/src/fileExplorer/ActionsFooter/style.module.css
+++ b/intuita-webview/src/fileExplorer/ActionsFooter/style.module.css
@@ -1,7 +1,7 @@
 .root {
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	width: 100%;
 	z-index: 1001;
 	height: 35px;
 	top: 0;


### PR DESCRIPTION
Before

![Screenshot 2023-07-06 at 07 56 27](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/567fb8a0-d90c-4eab-a5e8-f85e7827d99d)

After

![Screenshot 2023-07-06 at 07 56 37](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/eda22efc-1500-4f74-b5f4-6e0fa6544f59)
