### PR TITLE
INT-1327 Clean up some code + Remove focus-visible style from panel tab

### DIFF
--- a/intuita-webview/src/codemodList/App.tsx
+++ b/intuita-webview/src/codemodList/App.tsx
@@ -6,9 +6,8 @@ import SearchBar from '../shared/SearchBar';
 
 import TreeView from './TreeView';
 
-import styles from './style.module.css';
-
 import type { MainWebviewViewProps } from '../../../src/selectors/selectMainWebviewViewProps';
+import cn from 'classnames';
 
 const setSearchPhrase = (searchPhrase: string) => {
 	vscode.postMessage({
@@ -24,7 +23,7 @@ export const App = memo(
 			screenWidth: number | null;
 		},
 	) => (
-		<main className={styles.root}>
+		<main className={cn('w-full', 'h-full', 'overflow-y-auto')}>
 			<SearchBar
 				searchPhrase={props.searchPhrase}
 				setSearchPhrase={setSearchPhrase}

--- a/intuita-webview/src/codemodList/style.module.css
+++ b/intuita-webview/src/codemodList/style.module.css
@@ -1,5 +1,0 @@
-.root {
-	height: 100%;
-	width: 100%;
-	overflow-y: auto;
-}

--- a/intuita-webview/src/main/App.css
+++ b/intuita-webview/src/main/App.css
@@ -47,6 +47,10 @@
 	font-size: 11px;
 }
 
+.vscode-tab:focus-visible {
+	border: none;
+}
+
 .vscode-panel-view {
 	padding: 0px;
 }

--- a/intuita-webview/src/shared/SearchBar/index.tsx
+++ b/intuita-webview/src/shared/SearchBar/index.tsx
@@ -27,7 +27,7 @@ const SearchBar = (props: Props) => {
 
 				props.setSearchPhrase(event.target.value);
 			}}
-			className={styles.container}
+			className={cn(styles.container, 'w-full')}
 		>
 			<span
 				slot="start"

--- a/intuita-webview/src/shared/SearchBar/style.module.css
+++ b/intuita-webview/src/shared/SearchBar/style.module.css
@@ -1,7 +1,3 @@
-.container {
-	width: 100%;
-}
-
 .container:focus {
 	outline: none;
 }

--- a/intuita-webview/src/shared/util.css
+++ b/intuita-webview/src/shared/util.css
@@ -13,6 +13,10 @@
 	width: 50%;
 }
 
+.h-full {
+	height: 100%;
+}
+
 .flex-col {
 	flex-direction: column;
 }
@@ -157,9 +161,6 @@
 	pointer-events: none;
 }
 
-.h-full {
-	height: 100%;
-}
 .user-select-none {
 	user-select: none;
 }
@@ -170,6 +171,10 @@
 
 .overflow-hidden {
 	overflow: hidden;
+}
+
+.overflow-y-auto {
+	overflow-y: auto;
 }
 
 .codicon,


### PR DESCRIPTION
Remove the white border that appears when user navigates between panel tabs using keyboard

![Screenshot 2023-07-10 at 09 00 27](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/476aeaeb-c699-4696-a800-8e6afe07b511)
