### PR TITLE
INT-1301 all folders must come before all files given that they are at the same depth

### DIFF
--- a/src/selectors/selectExplorerTree.ts
+++ b/src/selectors/selectExplorerTree.ts
@@ -191,10 +191,13 @@ export const selectExplorerNodes = (
 			(hashA, hashB) => {
 				const childA = nodes[hashA];
 				const childB = nodes[hashB];
-				if (childA?.kind === 'DIRECTORY' && childB?.kind === 'FILE') {
+				if (!childA || !childB) {
+					return 0;
+				}
+				if (childA.kind === 'DIRECTORY' && childB.kind === 'FILE') {
 					return -1;
 				}
-				if (childA?.kind === 'FILE' && childB?.kind === 'DIRECTORY') {
+				if (childA.kind === 'FILE' && childB.kind === 'DIRECTORY') {
 					return 1;
 				}
 				return 0;


### PR DESCRIPTION
### Results

![Screenshot 2023-07-11 at 11 00 25](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/23c209fc-7931-42d3-821c-e7c267c9c4f4)
![Screenshot 2023-07-11 at 11 00 30](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/e5a3a286-f14f-4302-9e70-483d28fc026b)
![Screenshot 2023-07-11 at 11 00 40](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/1fcba9fb-484c-4887-a473-30e00dd97d94)
