### PR TITLE
Trigger Intuita Popover on hover only, not focus

### DIFF
--- a/intuita-webview/src/shared/IntuitaPopover/index.tsx
+++ b/intuita-webview/src/shared/IntuitaPopover/index.tsx
@@ -3,7 +3,15 @@ import Tippy, { TippyProps } from '@tippyjs/react';
 type Props = TippyProps;
 
 const IntuitaPopover = ({ delay = [800, 100], ...others }: Props) => {
-	return <Tippy arrow delay={delay} placement="auto" {...others} />;
+	return (
+		<Tippy
+			trigger="mouseenter"
+			arrow
+			delay={delay}
+			placement="auto"
+			{...others}
+		/>
+	);
 };
 
 export default IntuitaPopover;


### PR DESCRIPTION
part of https://linear.app/intuita/issue/INT-1275/improve-keyboard-navigation

#### Before
![Screenshot 2023-07-17 at 09 27 48](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/24ef4607-fea2-4826-bb1e-d252e5eeee7c)

#### After
![Screenshot 2023-07-17 at 09 28 04](https://github.com/intuita-inc/intuita-vscode-extension/assets/32841130/b64c2984-002c-428c-9854-0ae9154b82d4)
