### PR TITLE
INT-1389 Codemod via deeplink not being highlighted

### DIFF
--- a/intuita-webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
+++ b/intuita-webview/src/codemodList/CodemodNodeRenderer/Codemod.tsx
@@ -288,15 +288,14 @@ const Codemod = ({
 						</span>
 					)}
 					<div
-						className={cn(styles.actionGroup, {
-							focused: styles.focused,
-						})}
+						className={styles.actionGroup}
 						style={{
 							...getActionGroupStyle(
 								areButtonsVisible,
 								screenWidth,
 							),
 							...(editingPath && { opacity: 1, width: '100%' }),
+							...(focused && { opacity: 1 }),
 						}}
 					>
 						<span

--- a/intuita-webview/src/codemodList/CodemodNodeRenderer/style.module.css
+++ b/intuita-webview/src/codemodList/CodemodNodeRenderer/style.module.css
@@ -14,10 +14,8 @@
 	background-color: var(--vscode-list-hoverBackground);
 }
 
-.root:focus,
-.focused {
+.root:focus {
 	background-color: var(--vscode-list-activeSelectionBackground);
-	opacity: 1;
 }
 
 .root:focus-visible {


### PR DESCRIPTION
### Problems
- Directories that contain focused codemod aren't expanded.

### Claap: https://app.claap.io/intuita/int-1389-codemod-via-deeplink-not-being-highlighted-c-BT2DRbCjzO-Wpgek2M2vRpH