### PR TITLE
INT-1459 Update `IntuitaCertifiedCodemods` for new codemods

### DIFF
--- a/src/selectors/selectCodemodTree.ts
+++ b/src/selectors/selectCodemodTree.ts
@@ -17,6 +17,9 @@ const IntuitaCertifiedCodemods = [
 	'next/13/remove-next-export',
 	'next/13/replace-next-head',
 	'next/13/replace-next-router',
+	'next/13/upsert-use-client-directive',
+	'next/13/replace-next-head-repomod',
+	'next/13/app-router',
 ];
 
 interface CodemodNodeHashDigestBrand {


### PR DESCRIPTION
Otherwise, the verified symbol in codemod node ends up missing